### PR TITLE
refactoring: enhancement of error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "indicatif",
  "reqwest",
  "serde_json",
+ "thiserror",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ homedir = "0.3.6"
 indicatif = "0.18.3"
 reqwest = { version = "0.12.26", features = ["blocking", "json", "rustls-tls"], default-features = false }
 serde_json = "1.0.145"
+thiserror = "2.0.17"
 zip = "6.0.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="center">
 	<img src="https://github.com/geode-sdk/geode/raw/main/title.png" />
-	<h3 align="center">
-		On Linux
-	</h3>
 </p>
 
 # Install Geode on Linux (Rust version)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,56 @@
+use std::io;
+use colored::Colorize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum InstallerError {
+    #[error("Invalid choice. Please try again.")]
+    NotANumber,
+
+    #[error("Invalid input. Please enter a number.")]
+    InvalidNumber,
+
+    #[error("Failed to initialize installer: {0}")]
+    Init(String),
+
+    #[error("Installation failed: {0}")]
+    Installation(String),
+
+    #[error("An error occurred: {0}")]
+    Unknown(String),
+}
+
+impl InstallerError {
+    pub fn format(&self) -> String {
+        format!("❌ {}", self).red().bold().to_string()
+    }
+}
+
+impl From<io::Error> for InstallerError {
+    fn from(e: io::Error) -> Self {
+        InstallerError::Unknown(e.to_string())
+    }
+}
+
+impl From<reqwest::Error> for InstallerError {
+    fn from(e: reqwest::Error) -> Self {
+        InstallerError::Unknown(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for InstallerError {
+    fn from(e: serde_json::Error) -> Self {
+        InstallerError::Unknown(e.to_string())
+    }
+}
+
+impl From<zip::result::ZipError> for InstallerError {
+    fn from(e: zip::result::ZipError) -> Self {
+        InstallerError::Unknown(format!("Zip error: {}", e))
+    }
+}
+
+impl From<String> for InstallerError {
+    fn from(err: String) -> Self {
+        InstallerError::Installation(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod utils;
+pub mod errors;


### PR DESCRIPTION
Moved all errors to `error.rs` using `thiserror` crate.

- Unified all error handling under `InstallerError` (io, reqwest, zip, serde_json).
- Removed `process::exit` from the `run_interactive_loop()`.
- Improved error messages for clarity and structure